### PR TITLE
Updated demos.yaml to pull in demos from jbossdemocentral.org

### DIFF
--- a/demos.yaml
+++ b/demos.yaml
@@ -18,10 +18,12 @@
 - https://raw.githubusercontent.com/jboss-developer/jboss-developer-demos/master/javaee7-samples/servlets.yaml
 - https://raw.githubusercontent.com/jboss-developer/jboss-developer-demos/master/javaee7-samples/validation.yaml
 - https://raw.githubusercontent.com/jboss-developer/jboss-developer-demos/master/javaee7-samples/websocket.yaml
-- https://raw.githubusercontent.com/jboss-developer/jboss-developer-demos/master/fusebyexample/external-mq-fabric-client.yaml 
+- https://raw.githubusercontent.com/jboss-developer/jboss-developer-demos/master/fusebyexample/external-mq-fabric-client.yaml
 - https://raw.githubusercontent.com/jboss-developer/jboss-developer-demos/master/fusebyexample/kie-remote-example.yaml
 - https://raw.githubusercontent.com/weimeilin79/homeloan-part1/master/homeloan1.yaml
 - https://raw.githubusercontent.com/weimeilin79/homeloan-part2/master/homeloan2.yaml
 - https://raw.githubusercontent.com/weimeilin79/homeloan-part3/master/homeloan3.yaml
 - https://raw.githubusercontent.com/kpeeples/jboss-fuse-websockets-demo/master/fusewebsocket.yaml
 - https://raw.githubusercontent.com/kpeeples/jboss-a-mq-websockets-demo/master/fuseamqwebsockets.yaml
+- https://raw.githubusercontent.com/Dantheman720/continuous-delivery-demo/DemoYaml/demo.yaml
+- https://raw.githubusercontent.com/Dantheman720/site/RHDdemo/demo.yaml

--- a/demos.yaml
+++ b/demos.yaml
@@ -25,5 +25,5 @@
 - https://raw.githubusercontent.com/weimeilin79/homeloan-part3/master/homeloan3.yaml
 - https://raw.githubusercontent.com/kpeeples/jboss-fuse-websockets-demo/master/fusewebsocket.yaml
 - https://raw.githubusercontent.com/kpeeples/jboss-a-mq-websockets-demo/master/fuseamqwebsockets.yaml
-- https://raw.githubusercontent.com/Dantheman720/continuous-delivery-demo/DemoYaml/demo.yaml
-- https://raw.githubusercontent.com/Dantheman720/site/RHDdemo/demo.yaml
+- https://raw.githubusercontent.com/jbossdemocentral/continuous-delivery-demo/master/demo.yaml
+- https://raw.githubusercontent.com/jbossdemocentral/site/master/demo.yaml


### PR DESCRIPTION
I will submit PRs for:

- https://github.com/jbossdemocentral/site
- https://github.com/jbossdemocentral/continuous-delivery-demo

I wanted to make sure that this builds as expected beforehand.